### PR TITLE
fix documentation and modify get_positions child function of Pyrobot …

### DIFF
--- a/pyrobot/robot.py
+++ b/pyrobot/robot.py
@@ -885,7 +885,7 @@ class PyRobot():
                 redirect_uri=REDIRECT_URI,
                 credentials_path=CREDENTIALS_PATH
             )
-            >>> trading_robot_accounts = tradeconsole_session.get_accounts(
+            >>> trading_robot_accounts = trading_robot.session.get_accounts(
                 account_number="<YOUR ACCOUNT NUMBER>"
             )
             >>> trading_robot_accounts
@@ -1074,7 +1074,7 @@ class PyRobot():
                 redirect_uri=REDIRECT_URI,
                 credentials_path=CREDENTIALS_PATH
             )
-            >>> trading_robot_positions = tradeconsole_session.get_positions(
+            >>> trading_robot_positions = trading_robot.session.get_positions(
                 account_number="<YOUR ACCOUNT NUMBER>"
             )
             >>> trading_robot_positions
@@ -1152,7 +1152,7 @@ class PyRobot():
 
         if isinstance(positions_response, dict):
 
-            position_dict = {}
+        
 
             for account_type_key in positions_response:
 
@@ -1162,6 +1162,7 @@ class PyRobot():
                 positions = account_info['positions']
 
                 for position in positions:
+                    position_dict = {}
                     position_dict['account_number'] = account_id
                     position_dict['average_price'] = position['averagePrice']
                     position_dict['market_value'] = position['marketValue']
@@ -1191,7 +1192,7 @@ class PyRobot():
 
             for account in positions_response:
 
-                position_dict = {}
+
 
                 for account_type_key in account:
 
@@ -1201,6 +1202,7 @@ class PyRobot():
                     positions = account_info['positions']
 
                     for position in positions:
+                        position_dict = {}
                         position_dict['account_number'] = account_id
                         position_dict['average_price'] = position['averagePrice']
                         position_dict['market_value'] = position['marketValue']


### PR DESCRIPTION
…class

going through this file found a couple of what seem to be old methods in the documentation and when I used the get_positions() method it would pull my account but repeat one position over and over again.  after moving the position_dict = {} into the for loop it stopped overwriting the positions from my account.